### PR TITLE
Add Auto Close of Error Snack Bars

### DIFF
--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -1,5 +1,5 @@
 import { ErrorHandler, Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material';
+import { MatSnackBar, MatSnackBarRef } from '@angular/material';
 import { GeneralMessageErrorComponent } from '../../shared/error-toasters/general-message-error/general-message-error.component';
 import { FormErrorComponent } from '../../shared/error-toasters/form-error/form-error.component';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -14,6 +14,7 @@ const FILTERABLE = ['node_modules'];
   providedIn: 'root',
 })
 export class ErrorHandlingService implements ErrorHandler {
+  snackBarAutoCloseTime = 3000;
 
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 
@@ -29,6 +30,12 @@ export class ErrorHandlingService implements ErrorHandler {
     }
   }
 
+  private addAutoClose<T>(snackBarRef: MatSnackBarRef<T>) {
+    setTimeout(() => {
+      snackBarRef.dismiss();
+    }, this.snackBarAutoCloseTime);
+  }
+
   private cleanStack(stacktrace: string): string {
     return stacktrace
             .split('\n')
@@ -38,35 +45,41 @@ export class ErrorHandlingService implements ErrorHandler {
 
   // Ref: https://developer.github.com/v3/#client-errors
   private handleHttpError(error: HttpErrorResponse | RequestError, actionCallback?: () => void): void {
+    let snackBarRef = null;
     // Angular treats 304 Not Modified as an error, we will ignore it.
     if (error.status === 304) {
       return;
     }
 
     if (!navigator.onLine) {
-      this.handleGeneralError('No Internet Connection');
+      snackBarRef = this.handleGeneralError('No Internet Connection');
+      this.addAutoClose(snackBarRef);
       return;
     }
 
     switch (error.status) {
       case 500: // Internal Server Error.
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        snackBarRef = this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
         break;
       case 422: // Form errors
-        this.snackBar.openFromComponent(FormErrorComponent, {data: error});
+        snackBarRef = this.snackBar.openFromComponent(FormErrorComponent, {data: error});
         break;
       case 400: // Bad request
       case 401: // Unauthorized
       case 404: // Not found
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        snackBarRef = this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
         break;
       default:
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
-        return;
+        snackBarRef = this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+    }
+
+    if (snackBarRef) {
+      this.addAutoClose(snackBarRef);
     }
   }
 
   private handleGeneralError(error: string): void {
-    this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: {message: error}});
+    const snackBarRef = this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: {message: error}});
+    this.addAutoClose(snackBarRef);
   }
 }


### PR DESCRIPTION
Add the behavior of auto-closing the error snack bar after a certain time has passed.
I set the time to 3 seconds.

Reason: 
Within 3 seconds, users are very likely to have read the error message. This enhances the UX so that users do not have to manually close the error themselves after reading.

Demo:
https://user-images.githubusercontent.com/54733401/121800490-e5417400-cc64-11eb-9c57-dcdef01d3c04.mov

