### PR TITLE
Remove Placeholder Text

### DIFF
--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -26,7 +26,7 @@ export class NewIssueComponent implements OnInit {
   ngOnInit() {
     this.newIssueForm = this.formBuilder.group({
       title: ['', Validators.required],
-      description: ['No details provided.'],
+      description: [''],
       severity: ['', Validators.required],
       type: ['', Validators.required],
     });

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -8,9 +8,9 @@
         <mat-form-field appearance="outline" style="width: 100%">
           <mat-label></mat-label>
           <textarea (paste)="onPaste($event)" #commentTextArea (dragover)="disableCaretMovement($event)"
-                    id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
+                    id="{{ this.id }}" formControlName="{{ this.id }}" matInput
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20" class="text-input-area"></textarea>
+                    cdkAutosizeMaxRows="20" class="text-input-area" placeholder="{{ this.placeholderText }}"></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>
@@ -23,7 +23,7 @@
                    type="file" class="file" (change)="onFileInputUpload($event, fileInput)">
           </div>
         </mat-form-field>
-        </div>
+      </div>
     </mat-tab>
     <mat-tab label="Preview">
       <div class="tab-content" style="min-height: 228px">

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -31,7 +31,7 @@ export class CommentEditorComponent implements OnInit {
   @Input() id: string; // Compulsory Input
 
   @Input() initialDescription?: string;
-  placeholderText: string = 'No details provided.';
+  placeholderText = 'No details provided.';
 
   // Allows the comment editor to control the overall form's completeness.
   @Input() isFormPending?: boolean;

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -31,6 +31,7 @@ export class CommentEditorComponent implements OnInit {
   @Input() id: string; // Compulsory Input
 
   @Input() initialDescription?: string;
+  placeholderText: string = 'No details provided.';
 
   // Allows the comment editor to control the overall form's completeness.
   @Input() isFormPending?: boolean;

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -45,7 +45,7 @@ export class NewTeamResponseComponent implements OnInit {
     });
     this.duplicatedIssueList = this.getDupIssueList();
     this.newTeamResponseForm = this.formBuilder.group({
-      description: ['No response provided.'],
+      description: [''],
       severity: [this.issue.severity, Validators.required],
       type: [this.issue.type, Validators.required],
       responseTag: [this.issue.responseTag, Validators.required],


### PR DESCRIPTION
As stated in this [issue](https://github.com/CATcher-org/CATcher/issues/629), change placeholder text to hint instead for new issues, removing the trouble for user to manually delete.

Reason:
Improve user experience 😄 

Screenshot:
![image](https://user-images.githubusercontent.com/54733401/121800796-6816fe80-cc66-11eb-95f3-669648e830dc.png)
